### PR TITLE
Fix formatting of version command

### DIFF
--- a/Sources/utiluti/AppCommands.swift
+++ b/Sources/utiluti/AppCommands.swift
@@ -151,7 +151,7 @@ struct AppCommands: AsyncParsableCommand {
     static let configuration
     = CommandConfiguration(
       commandName: "version",
-      abstract: "Show the version for an app at the path",
+      abstract: "Show the version for an app at the path"
     )
 
     @Argument(help:ArgumentHelp("path to the app", valueName: "path"))


### PR DESCRIPTION
Without this, utiluti fails to build for me with Swift 6.0.