### PR TITLE
feat: Launch Services support for file extensions

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -140,6 +140,23 @@ super types: ["public.item", "public.content", "public.data", "public.text"]
 default app: com.barebones.bbedit (/Applications/BBEdit.app)
 ```
 
+When you pass `--extension/-e`, `utiluti` resolves the extension to a UTI first and uses the UTI-based workflow when that yields a usable result. If the UTI route does not produce a usable handler, `utiluti` falls back to an extension-specific Launch Services override. This matters for extensions that resolve to a dynamic `dyn.*` identifier.
+
+```shell
+$ utiluti type set -e xcodeproj com.apple.dt.Xcode
+set com.apple.dt.Xcode for extension:xcodeproj
+```
+
+```shell
+$ utiluti type info -e xcodeproj
+requested extension: xcodeproj
+resolved UTI: dyn.ah62d4rv4ge81u25tqvw1a6xtrk
+dynamic UTI: true
+public.filename-extension: ["xcodeproj"]
+super types: ["public.data", "public.item"]
+default app: com.apple.dt.Xcode
+```
+
 ## Getting an App's declarations and other information
 
 `utiluti` can list the UTIs and url schemes an app has declared in their Info.plist:

--- a/Sources/utiluti/ApplicationResolver.swift
+++ b/Sources/utiluti/ApplicationResolver.swift
@@ -1,0 +1,145 @@
+//
+//  ApplicationResolver.swift
+//  utiluti
+//
+
+import Foundation
+import CoreServices
+
+enum ApplicationResolver {
+  private struct Cache {
+    var appURLs = [String: URL]()
+    var missingAppURLs = Set<String>()
+    var bundleIdentifiers = [String: String]()
+    var missingBundleIdentifiers = Set<String>()
+  }
+
+  private static let cache = LockedValue(Cache())
+
+  /**
+   The application directories Foundation reports for all domains on this Mac.
+   */
+  private static let searchRoots: [URL] = {
+    let urls = FileManager.default.urls(for: .allApplicationsDirectory, in: .allDomainsMask)
+    var seenPaths = Set<String>()
+
+    return urls.compactMap { url in
+      let standardizedURL = url.standardizedFileURL
+      guard seenPaths.insert(standardizedURL.path).inserted else { return nil }
+      guard FileManager.default.fileExists(atPath: standardizedURL.path) else { return nil }
+      return standardizedURL
+    }
+  }()
+
+  /**
+   Resolve a bundle identifier to an application bundle URL.
+   */
+  static func appURL(forBundleIdentifier identifier: String) -> URL? {
+    let cacheKey = identifier.lowercased()
+    let cachedResult = cache.withLock { cache -> (Bool, URL?) in
+      if let appURL = cache.appURLs[cacheKey] {
+        return (true, appURL)
+      }
+      if cache.missingAppURLs.contains(cacheKey) {
+        return (true, nil)
+      }
+      return (false, nil)
+    }
+    if cachedResult.0 {
+      return cachedResult.1
+    }
+
+    if let result = LSCopyApplicationURLsForBundleIdentifier(identifier as CFString, nil) {
+      let appURLs = result.takeRetainedValue() as Array
+      if let appURL = appURLs.first as? URL {
+        let standardizedURL = appURL.standardizedFileURL
+        cache.withLock { cache in
+          cache.appURLs[cacheKey] = standardizedURL
+          cache.missingAppURLs.remove(cacheKey)
+        }
+        return standardizedURL
+      }
+    }
+
+    let appURL = appURLFromFilesystem(forBundleIdentifier: identifier)
+    cache.withLock { cache in
+      if let appURL {
+        cache.appURLs[cacheKey] = appURL
+        cache.missingAppURLs.remove(cacheKey)
+      } else {
+        cache.missingAppURLs.insert(cacheKey)
+      }
+    }
+
+    return appURL
+  }
+
+  /**
+   Read the bundle identifier from an application bundle URL when command
+   output needs an identifier rather than a filesystem path.
+   */
+  static func bundleIdentifier(for appURL: URL) -> String? {
+    let standardizedURL = appURL.standardizedFileURL
+    let cacheKey = standardizedURL.path
+
+    let cachedResult = cache.withLock { cache -> (Bool, String?) in
+      if let bundleIdentifier = cache.bundleIdentifiers[cacheKey] {
+        return (true, bundleIdentifier)
+      }
+      if cache.missingBundleIdentifiers.contains(cacheKey) {
+        return (true, nil)
+      }
+      return (false, nil)
+    }
+    if cachedResult.0 {
+      return cachedResult.1
+    }
+
+    let bundleIdentifier = Bundle(url: standardizedURL)?.bundleIdentifier
+    cache.withLock { cache in
+      if let bundleIdentifier {
+        cache.bundleIdentifiers[cacheKey] = bundleIdentifier
+        cache.missingBundleIdentifiers.remove(cacheKey)
+      } else {
+        cache.missingBundleIdentifiers.insert(cacheKey)
+      }
+    }
+
+    return bundleIdentifier
+  }
+
+  /**
+   Scan the known application directories for a matching bundle identifier.
+   */
+  private static func appURLFromFilesystem(forBundleIdentifier identifier: String) -> URL? {
+    for root in searchRoots {
+      if let appURL = findApplication(in: root, bundleIdentifier: identifier) {
+        return appURL.standardizedFileURL
+      }
+    }
+
+    return nil
+  }
+
+  /**
+   Walk one application root and inspect application bundles found there.
+   */
+  private static func findApplication(in root: URL, bundleIdentifier targetBundleIdentifier: String) -> URL? {
+    guard let enumerator = FileManager.default.enumerator(
+      at: root,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles, .skipsPackageDescendants]
+    ) else { return nil }
+
+    for case let url as URL in enumerator {
+      guard url.pathExtension == "app" else { continue }
+
+      if let discoveredBundleIdentifier = bundleIdentifier(for: url),
+         discoveredBundleIdentifier.caseInsensitiveCompare(targetBundleIdentifier) == .orderedSame {
+        return url.standardizedFileURL
+      }
+    }
+
+    return nil
+  }
+}

--- a/Sources/utiluti/FileTypeProbe.swift
+++ b/Sources/utiluti/FileTypeProbe.swift
@@ -1,0 +1,26 @@
+//
+//  FileTypeProbe.swift
+//  utiluti
+//
+
+import Foundation
+
+enum FileTypeProbe {
+  /**
+   Some file-association APIs only answer accurately for a concrete file URL,
+   so create a short-lived empty probe file and remove it immediately after.
+   */
+  static func withTemporaryFileURL<T>(forExtension fileExtension: String, perform body: (URL) -> T) -> T {
+    let normalizedExtension = TypeTarget.normalizeExtension(fileExtension)
+    let tempDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("utiluti-\(UUID().uuidString)", isDirectory: true)
+    let baseFileURL = tempDirectory.appendingPathComponent("utiluti-probe")
+    let fileURL = normalizedExtension.isEmpty ? baseFileURL : baseFileURL.appendingPathExtension(normalizedExtension)
+
+    try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: fileURL.path, contents: Data())
+    defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+    return body(fileURL)
+  }
+}

--- a/Sources/utiluti/GetUTI.swift
+++ b/Sources/utiluti/GetUTI.swift
@@ -22,7 +22,9 @@ struct GetUTI: AsyncParsableCommand {
   var showDynamic = false
   
   func run() async {
-    guard let utype = UTType(filenameExtension: fileExtension) else {
+    let normalizedExtension = TypeTarget.normalizeExtension(fileExtension)
+
+    guard let utype = UTType(filenameExtension: normalizedExtension) else {
       Self.exit(withError: ExitCode(3))
     }
     

--- a/Sources/utiluti/LSKit+TypeTargetResolution.swift
+++ b/Sources/utiluti/LSKit+TypeTargetResolution.swift
@@ -1,0 +1,197 @@
+//
+//  LSKit+TypeTargetResolution.swift
+//  utiluti
+//
+
+import Foundation
+import AppKit
+import CoreServices
+import UniformTypeIdentifiers
+
+extension LSKit {
+  private struct HandlerResolution {
+    let bundleIdentifier: String?
+    let appURL: URL?
+  }
+
+  static func appURLs(for target: TypeTarget) -> [URL] {
+    for candidate in candidates(for: target) {
+      let candidateAppURLs = appURLs(for: candidate)
+      if !candidateAppURLs.isEmpty {
+        return candidateAppURLs
+      }
+    }
+
+    return []
+  }
+
+  static func defaultAppDetails(for target: TypeTarget) -> (bundleIdentifier: String?, appURL: URL?) {
+    let resolution = handlerResolution(for: target)
+    return (resolution?.bundleIdentifier, resolution?.appURL)
+  }
+
+  private static func handlerResolution(for target: TypeTarget) -> HandlerResolution? {
+    for candidate in candidates(for: target) {
+      if let resolution = handlerResolution(for: candidate) {
+        return resolution
+      }
+    }
+
+    return nil
+  }
+
+  static func defaultAppURL(for target: TypeTarget) -> URL? {
+    defaultAppDetails(for: target).appURL
+  }
+
+  static func defaultBundleIdentifier(for target: TypeTarget) -> String? {
+    defaultAppDetails(for: target).bundleIdentifier
+  }
+
+  @discardableResult
+  static func setDefaultApp(identifier: String, for target: TypeTarget) async -> OSStatus {
+    let candidates = candidates(for: target)
+
+    for (index, candidate) in candidates.enumerated() {
+      let result = await setDefaultApp(identifier: identifier, for: candidate)
+      if result == 0 || index == candidates.index(before: candidates.endIndex) {
+        return result
+      }
+    }
+
+    return 1
+  }
+
+  /**
+   When reading Launch Services defaults, prefer the most general role first,
+   then progressively more specific roles so we can still recover a usable app
+   when only an editor/viewer-specific override exists.
+   */
+  private static let preferredRoles: [LSRolesMask] = [.all, .editor, .viewer, .shell]
+
+  private enum Candidate {
+    case typeIdentifier(String)
+    case fileExtension(String)
+  }
+
+  /**
+   Build the lookup order for a type target.
+   */
+  private static func candidates(for target: TypeTarget) -> [Candidate] {
+    switch target {
+    case .uti(let utidentifier):
+      return [.typeIdentifier(utidentifier)]
+    case .fileExtension(let fileExtension):
+      if let utidentifier = target.preferredTypeIdentifier {
+        return [.typeIdentifier(utidentifier), .fileExtension(fileExtension)]
+      } else {
+        return [.fileExtension(fileExtension)]
+      }
+    }
+  }
+
+  private static func appURLs(for candidate: Candidate) -> [URL] {
+    switch candidate {
+    case .typeIdentifier(let utidentifier):
+      return appURLs(forTypeIdentifier: utidentifier)
+    case .fileExtension(let fileExtension):
+      return appURLsFromFileExtension(fileExtension)
+    }
+  }
+
+  private static func handlerResolution(for candidate: Candidate) -> HandlerResolution? {
+    switch candidate {
+    case .typeIdentifier(let utidentifier):
+      return handlerResolution(forTypeIdentifier: utidentifier)
+    case .fileExtension(let fileExtension):
+      return handlerResolution(forExtension: fileExtension)
+    }
+  }
+
+  private static func setDefaultApp(identifier: String, for candidate: Candidate) async -> OSStatus {
+    switch candidate {
+    case .typeIdentifier(let utidentifier):
+      return await setDefaultApp(identifier: identifier, forTypeIdentifier: utidentifier)
+    case .fileExtension(let fileExtension):
+      return LaunchServicesPreferences().setDefaultEditor(
+        bundleIdentifier: identifier,
+        forExtension: fileExtension
+      ) ? 0 : 1
+    }
+  }
+
+  private static func handlerResolution(forTypeIdentifier utidentifier: String) -> HandlerResolution? {
+    let bundleIdentifier = preferredBundleIdentifierOverride(forTypeIdentifier: utidentifier)
+    let appURL = bundleIdentifier.flatMap { ApplicationResolver.appURL(forBundleIdentifier: $0) }
+      ?? defaultAppURLFromLaunchServices(forTypeIdentifier: utidentifier)
+    let resolvedBundleIdentifier = bundleIdentifier ?? appURL.flatMap { ApplicationResolver.bundleIdentifier(for: $0) }
+
+    if resolvedBundleIdentifier == nil && appURL == nil {
+      return nil
+    }
+
+    return HandlerResolution(bundleIdentifier: resolvedBundleIdentifier, appURL: appURL)
+  }
+
+  private static func handlerResolution(forExtension fileExtension: String) -> HandlerResolution? {
+    let bundleIdentifier = LaunchServicesPreferences().preferredBundleIdentifier(forExtension: fileExtension)
+    let appURL = bundleIdentifier.flatMap { ApplicationResolver.appURL(forBundleIdentifier: $0) }
+      ?? defaultAppURLFromFileExtension(fileExtension)
+    let resolvedBundleIdentifier = bundleIdentifier ?? appURL.flatMap { ApplicationResolver.bundleIdentifier(for: $0) }
+
+    if resolvedBundleIdentifier == nil && appURL == nil {
+      return nil
+    }
+
+    return HandlerResolution(bundleIdentifier: resolvedBundleIdentifier, appURL: appURL)
+  }
+
+  private static func preferredBundleIdentifierOverride(forTypeIdentifier utidentifier: String) -> String? {
+    if let bundleIdentifier = LaunchServicesPreferences().preferredBundleIdentifier(forTypeIdentifier: utidentifier) {
+      return bundleIdentifier
+    }
+
+    for role in preferredRoles {
+      if let bundleIdentifier = LSCopyDefaultRoleHandlerForContentType(utidentifier as CFString, role)?
+        .takeRetainedValue() as String? {
+        return bundleIdentifier
+      }
+    }
+
+    return nil
+  }
+
+  private static func appURLsFromFileExtension(_ fileExtension: String) -> [URL] {
+    FileTypeProbe.withTemporaryFileURL(forExtension: fileExtension) { fileURL in
+      if #available(macOS 12, *) {
+        return LaunchServicesSupport.uniqueAppURLs(NSWorkspace.shared.urlsForApplications(toOpen: fileURL))
+      } else {
+        return LaunchServicesSupport.appURLs(from: LSCopyApplicationURLsForURL(fileURL as CFURL, .all))
+      }
+    }
+  }
+
+  private static func defaultAppURLFromLaunchServices(forTypeIdentifier utidentifier: String) -> URL? {
+    if #available(macOS 12, *) {
+      guard let utype = UTType(utidentifier) else { return nil }
+      return LaunchServicesSupport.standardizedAppURL(NSWorkspace.shared.urlForApplication(toOpen: utype))
+    } else {
+      return LaunchServicesSupport.standardizedAppURL(
+        LSCopyDefaultApplicationURLForContentType(utidentifier as CFString, .all, nil)?
+          .takeRetainedValue() as URL?
+      )
+    }
+  }
+
+  private static func defaultAppURLFromFileExtension(_ fileExtension: String) -> URL? {
+    FileTypeProbe.withTemporaryFileURL(forExtension: fileExtension) { fileURL in
+      if #available(macOS 12, *) {
+        return LaunchServicesSupport.standardizedAppURL(NSWorkspace.shared.urlForApplication(toOpen: fileURL))
+      } else {
+        return LaunchServicesSupport.standardizedAppURL(
+          LSCopyDefaultApplicationURLForURL(fileURL as CFURL, .all, nil)?.takeRetainedValue() as URL?
+        )
+      }
+    }
+  }
+}

--- a/Sources/utiluti/LSKit.swift
+++ b/Sources/utiluti/LSKit.swift
@@ -7,57 +7,44 @@
 
 import Foundation
 import AppKit
+import CoreServices
 import UniformTypeIdentifiers
 
 struct LSKit {
-  
   /**
    returns a list of URLs to applications that can open URLs starting with the scheme
    - Parameter scheme: url scheme (excluding the `:` or `/`, e.g. `http`)
    - Returns: array of app URLs
    */
   static func appURLs(forScheme scheme: String) -> [URL] {
-    guard let url = URL(string: "\(scheme):") else { return [URL]() }
-    
+    guard let schemeURL = URL(string: "\(scheme):") else { return [] }
+
     if #available(macOS 12, *) {
-      //print("running on macOS 12, using NSWorkspace")
       let ws = NSWorkspace.shared
-      return ws.urlsForApplications(toOpen: url)
+      return LaunchServicesSupport.uniqueAppURLs(ws.urlsForApplications(toOpen: schemeURL))
     } else {
-      var urlList = [URL]()
-      if let result = LSCopyApplicationURLsForURL(url as CFURL, .all) {
-        let cfURLList = result.takeRetainedValue() as Array
-        for item in cfURLList {
-          if let appURL = item as? URL {
-            urlList.append(appURL)
-          }
-        }
-      }
-      return urlList
+      return LaunchServicesSupport.appURLs(from: LSCopyApplicationURLsForURL(schemeURL as CFURL, .all))
     }
   }
-  
+
   /**
    returns URL to the default application for URLs starting with scheme
    - Parameter scheme: url scheme (excluding the `:` or `/`, e.g. `http`)
    - Returns: urls to default application
    */
   static func defaultAppURL(forScheme scheme: String) -> URL? {
-    guard let url = URL(string: "\(scheme):") else { return nil }
-    
+    guard let schemeURL = URL(string: "\(scheme):") else { return nil }
+
     if #available(macOS 12, *) {
-      //print("running on macOS 12, using NSWorkspace")
       let ws = NSWorkspace.shared
-      return ws.urlForApplication(toOpen: url)
+      return LaunchServicesSupport.standardizedAppURL(ws.urlForApplication(toOpen: schemeURL))
     } else {
-      if let result = LSCopyDefaultApplicationURLForURL(url as CFURL, .all, nil) {
-        let appURL = result.takeRetainedValue() as URL
-        return appURL
-      }
-      return nil
+      return LaunchServicesSupport.standardizedAppURL(
+        LSCopyDefaultApplicationURLForURL(schemeURL as CFURL, .all, nil)?.takeRetainedValue() as URL?
+      )
     }
   }
-  
+
   /**
    set the default app for scheme to the app with the identifier
    - Parameters:
@@ -65,26 +52,22 @@ struct LSKit {
    - scheme: url scheme (excluding the `:` or `/`, e.g. `http`)
    - Returns: OSStatus (discardable)
    */
-  @discardableResult static func setDefaultApp(identifier: String, forScheme scheme: String) async -> OSStatus {
+  @discardableResult
+  static func setDefaultApp(identifier: String, forScheme scheme: String) async -> OSStatus {
     if #available(macOS 12, *) {
-      // print("running on macOS 12, using NSWorkspace")
       do {
         let ws = NSWorkspace.shared
-        guard let appURL = ws.urlForApplication(withBundleIdentifier: identifier) else { return 1 }
+        guard let appURL = ApplicationResolver.appURL(forBundleIdentifier: identifier) else { return 1 }
         try await ws.setDefaultApplication(at: appURL, toOpenURLsWithScheme: scheme)
         return 0
       } catch {
-        if let err = error as? CocoaError, let underlyingError = err.errorUserInfo["NSUnderlyingError"] as? NSError {
-          return OSStatus(clamping: underlyingError.code)
-        } else {
-          return 1
-        }
+        return LaunchServicesSupport.osStatus(from: error)
       }
     } else {
       return LSSetDefaultHandlerForURLScheme(scheme as CFString, identifier as CFString)
     }
   }
-  
+
   /**
    returns a list of URLs to applications that can open the given type identifier
    - Parameter forTypeIdentifier: Uniform Type Identifier, e.g. `public.html`
@@ -92,74 +75,47 @@ struct LSKit {
    */
   static func appURLs(forTypeIdentifier utidentifier: String) -> [URL] {
     if #available(macOS 12, *) {
-      //print("running on macOS 12, using NSWorkspace")
       let ws = NSWorkspace.shared
-      guard let utype = UTType(utidentifier) else {
-        return [URL]()
-      }
-      return ws.urlsForApplications(toOpen: utype)
+      guard let utype = UTType(utidentifier) else { return [] }
+      return LaunchServicesSupport.uniqueAppURLs(ws.urlsForApplications(toOpen: utype))
     } else {
-      var urlList = [URL]()
-      if let result = LSCopyAllRoleHandlersForContentType(utidentifier as CFString, .all) {
-        let cfURLList = result.takeRetainedValue() as Array
-        for item in cfURLList {
-          if let appURL = item as? URL {
-            urlList.append(appURL)
-          }
-        }
-      }
-      return urlList
-    }
-  }
-  
-  /**
-   returns URL to the default application for the given type identifier
-   - Parameter forTypeIdentifier: url scheme (excluding the `:` or `/`, e.g. `http`)
-   - Returns: url to default application
-   */
-  static func defaultAppURL(forTypeIdentifier utidentifier: String) -> URL? {
-    if #available(macOS 12, *) {
-      //print("running on macOS 12, using NSWorkspace")
-      guard let utype = UTType(utidentifier) else {
-        return nil
-      }
-      let ws = NSWorkspace.shared
-      return ws.urlForApplication(toOpen: utype)
-    } else {
-      if let result = LSCopyDefaultApplicationURLForContentType(utidentifier as CFString, .all, nil) {
-        let appURL = result.takeRetainedValue() as URL
-        return appURL
-      }
-      return nil
+      return LaunchServicesSupport.appURLs(from: LSCopyAllRoleHandlersForContentType(utidentifier as CFString, .all))
     }
   }
 
   /**
-   set the default app for type identifier to the app with the bundle indentifier
+   returns URL to the default application for the given type identifier
+   - Parameter forTypeIdentifier: Uniform Type Identifier, e.g. `public.html`
+   - Returns: url to default application
+   */
+  static func defaultAppURL(forTypeIdentifier utidentifier: String) -> URL? {
+    defaultAppDetails(for: .uti(utidentifier)).appURL
+  }
+
+  static func defaultBundleIdentifier(forTypeIdentifier utidentifier: String) -> String? {
+    defaultAppDetails(for: .uti(utidentifier)).bundleIdentifier
+  }
+
+  /**
+   set the default app for type identifier to the app with the bundle identifier
    - Parameters:
    - identifier: bundle id of the new default application
    - forTypeIdentifier: uniform type identifier ( e.g. `public.html`)
    - Returns: OSStatus (discardable)
    */
-  @discardableResult static func setDefaultApp(identifier: String, forTypeIdentifier utidentifier: String) async -> OSStatus {
+  @discardableResult
+  static func setDefaultApp(identifier: String, forTypeIdentifier utidentifier: String) async -> OSStatus {
     if #available(macOS 12, *) {
-      // print("running on macOS 12, using NSWorkspace")
-      guard let utype = UTType(utidentifier) else {
-        return 1
-      }
-      
+      guard let utype = UTType(utidentifier),
+            let appURL = ApplicationResolver.appURL(forBundleIdentifier: identifier)
+      else { return 1 }
+
       do {
         let ws = NSWorkspace.shared
-        guard let appURL = ws.urlForApplication(withBundleIdentifier: identifier) else { return 1 }
         try await ws.setDefaultApplication(at: appURL, toOpen: utype)
         return 0
       } catch {
-        // err is an NSError wrapped in a CocoaError
-        if let err = error as? CocoaError, let underlyingError = err.errorUserInfo["NSUnderlyingError"] as? NSError {
-          return OSStatus(clamping: underlyingError.code)
-        } else {
-          return 1
-        }
+        return LaunchServicesSupport.osStatus(from: error)
       }
     } else {
       return LSSetDefaultRoleHandlerForContentType(utidentifier as CFString, .all, identifier as CFString)

--- a/Sources/utiluti/LaunchServicesHandlerEntry.swift
+++ b/Sources/utiluti/LaunchServicesHandlerEntry.swift
@@ -1,0 +1,64 @@
+//
+//  LaunchServicesHandlerEntry.swift
+//  utiluti
+//
+
+import Foundation
+
+struct LaunchServicesHandlerEntry {
+  private enum Key {
+    static let contentType = "LSHandlerContentType"
+    static let contentTag = "LSHandlerContentTag"
+    static let contentTagClass = "LSHandlerContentTagClass"
+    static let preferredVersions = "LSHandlerPreferredVersions"
+    static let roleAll = "LSHandlerRoleAll"
+    static let roleEditor = "LSHandlerRoleEditor"
+    static let roleViewer = "LSHandlerRoleViewer"
+    static let roleShell = "LSHandlerRoleShell"
+  }
+
+  static let filenameExtensionTagClass = "public.filename-extension"
+
+  private let storage: [String:Any]
+
+  init(storage: [String:Any]) {
+    self.storage = storage
+  }
+
+  var propertyListRepresentation: [String:Any] {
+    storage
+  }
+
+  var preferredBundleIdentifier: String? {
+    storage[Key.roleAll] as? String
+      ?? storage[Key.roleEditor] as? String
+      ?? storage[Key.roleViewer] as? String
+      ?? storage[Key.roleShell] as? String
+  }
+
+  func matches(typeIdentifier: String) -> Bool {
+    (storage[Key.contentType] as? String) == typeIdentifier
+  }
+
+  func matches(fileExtension normalizedExtension: String) -> Bool {
+    guard let tagClass = storage[Key.contentTagClass] as? String,
+          tagClass == Self.filenameExtensionTagClass,
+          let tag = storage[Key.contentTag] as? String
+    else { return false }
+
+    return TypeTarget.normalizeExtension(tag) == normalizedExtension
+  }
+
+  static func extensionEditorOverride(bundleIdentifier: String, fileExtension: String) -> Self {
+    let normalizedExtension = TypeTarget.normalizeExtension(fileExtension)
+
+    return Self(storage: [
+      Key.contentTag: normalizedExtension,
+      Key.contentTagClass: filenameExtensionTagClass,
+      Key.preferredVersions: [
+        Key.roleEditor: "-"
+      ],
+      Key.roleEditor: bundleIdentifier
+    ])
+  }
+}

--- a/Sources/utiluti/LaunchServicesPreferences.swift
+++ b/Sources/utiluti/LaunchServicesPreferences.swift
@@ -1,0 +1,154 @@
+//
+//  LaunchServicesPreferences.swift
+//  utiluti
+//
+
+import Foundation
+
+struct LaunchServicesPreferences {
+  static let relativePath = "Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+  static let handlersKey = "LSHandlers"
+
+  private struct Cache {
+    var dictionaries = [String: [String:Any]]()
+    var handlers = [String: [LaunchServicesHandlerEntry]]()
+  }
+
+  private static let cache = LockedValue(Cache())
+
+  private let fileURL: URL
+
+  init() {
+    self.fileURL = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(Self.relativePath, isDirectory: false)
+  }
+
+  /**
+   Read the current per-user Launch Services handler overrides.
+   */
+  var handlers: [LaunchServicesHandlerEntry] {
+    if let cachedHandlers = Self.cache.withLock({ $0.handlers[cacheKey] }) {
+      return cachedHandlers
+    }
+
+    let rawHandlers = dictionary[Self.handlersKey] as? [[String:Any]] ?? []
+    let handlers = rawHandlers.map(LaunchServicesHandlerEntry.init(storage:))
+    Self.cache.withLock { $0.handlers[cacheKey] = handlers }
+    return handlers
+  }
+
+  /**
+   Look for an extension-specific override such as
+   `LSHandlerContentTag = go` and return the preferred bundle identifier.
+   */
+  func preferredBundleIdentifier(forExtension fileExtension: String) -> String? {
+    Self.preferredBundleIdentifier(forExtension: fileExtension, in: handlers)
+  }
+
+  /**
+   Look for a content-type override such as
+   `LSHandlerContentType = public.plain-text`.
+   */
+  func preferredBundleIdentifier(forTypeIdentifier utidentifier: String) -> String? {
+    Self.preferredBundleIdentifier(forTypeIdentifier: utidentifier, in: handlers)
+  }
+
+  @discardableResult
+  /**
+   Write or replace the user's extension-specific editor override while leaving
+   unrelated Launch Services handler entries untouched.
+   */
+  func setDefaultEditor(bundleIdentifier: String, forExtension fileExtension: String) -> Bool {
+    let updatedHandlers = Self.upsertingExtensionHandler(
+      bundleIdentifier: bundleIdentifier,
+      forExtension: fileExtension,
+      in: handlers
+    )
+
+    var updatedDictionary = dictionary
+    updatedDictionary[Self.handlersKey] = updatedHandlers.map(\.propertyListRepresentation)
+
+    do {
+      try FileManager.default.createDirectory(
+        at: fileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+        attributes: nil
+      )
+      let plistData = try PropertyListSerialization.data(
+        fromPropertyList: updatedDictionary,
+        format: .xml,
+        options: 0
+      )
+      try plistData.write(to: fileURL, options: .atomic)
+      Self.cache.withLock { cache in
+        cache.dictionaries[cacheKey] = updatedDictionary
+        cache.handlers[cacheKey] = updatedHandlers
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   Replace any existing override for the same extension with a single
+   normalized `public.filename-extension` handler entry.
+   */
+  private static func upsertingExtensionHandler(
+    bundleIdentifier: String,
+    forExtension fileExtension: String,
+    in handlers: [LaunchServicesHandlerEntry]
+  ) -> [LaunchServicesHandlerEntry] {
+    let normalizedExtension = TypeTarget.normalizeExtension(fileExtension)
+    let remainingHandlers = handlers.filter { !$0.matches(fileExtension: normalizedExtension) }
+
+    var updatedHandlers = remainingHandlers
+    updatedHandlers.append(
+      .extensionEditorOverride(bundleIdentifier: bundleIdentifier, fileExtension: normalizedExtension)
+    )
+
+    return updatedHandlers
+  }
+
+  private static func preferredBundleIdentifier(
+    forExtension fileExtension: String,
+    in handlers: [LaunchServicesHandlerEntry]
+  ) -> String? {
+    let normalizedExtension = TypeTarget.normalizeExtension(fileExtension)
+    return handlers.last(where: { $0.matches(fileExtension: normalizedExtension) })?.preferredBundleIdentifier
+  }
+
+  private static func preferredBundleIdentifier(
+    forTypeIdentifier utidentifier: String,
+    in handlers: [LaunchServicesHandlerEntry]
+  ) -> String? {
+    handlers.last(where: { $0.matches(typeIdentifier: utidentifier) })?.preferredBundleIdentifier
+  }
+
+  /**
+   Load the Launch Services secure plist directly because the `LSHandlers`
+   array is the source of truth for the per-user overrides we need to read
+   and update.
+   */
+  private var dictionary: [String:Any] {
+    if let cachedDictionary = Self.cache.withLock({ $0.dictionaries[cacheKey] }) {
+      return cachedDictionary
+    }
+
+    guard let data = try? Data(contentsOf: fileURL),
+          let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+          let dictionary = plist as? [String:Any]
+    else {
+      Self.cache.withLock { $0.dictionaries[cacheKey] = [:] }
+      return [:]
+    }
+
+    Self.cache.withLock { $0.dictionaries[cacheKey] = dictionary }
+
+    return dictionary
+  }
+
+  private var cacheKey: String {
+    fileURL.path
+  }
+}

--- a/Sources/utiluti/LaunchServicesSupport.swift
+++ b/Sources/utiluti/LaunchServicesSupport.swift
@@ -1,0 +1,57 @@
+//
+//  LaunchServicesSupport.swift
+//  utiluti
+//
+
+import Foundation
+
+enum LaunchServicesSupport {
+  /**
+   Some Launch Services APIs return URLs directly, while others return bundle
+   identifiers that still need to be resolved back to app bundles.
+   */
+  static func appURLs(from result: Unmanaged<CFArray>?) -> [URL] {
+    guard let result else { return [] }
+
+    let items = result.takeRetainedValue() as Array
+    var appURLs = [URL]()
+
+    for item in items {
+      if let appURL = item as? URL {
+        appURLs.append(appURL)
+      } else if let bundleIdentifier = item as? String,
+                let appURL = ApplicationResolver.appURL(forBundleIdentifier: bundleIdentifier) {
+        appURLs.append(appURL)
+      }
+    }
+
+    return uniqueAppURLs(appURLs)
+  }
+
+  static func standardizedAppURL(_ appURL: URL?) -> URL? {
+    appURL?.standardizedFileURL
+  }
+
+  static func uniqueAppURLs(_ appURLs: [URL]) -> [URL] {
+    var seenPaths = Set<String>()
+
+    return appURLs.compactMap { appURL in
+      let standardizedURL = appURL.standardizedFileURL
+      guard seenPaths.insert(standardizedURL.path).inserted else { return nil }
+      return standardizedURL
+    }
+  }
+
+  /**
+   AppKit wraps Launch Services failures in `CocoaError`. Pull the underlying
+   Launch Services status code back out so the CLI keeps reporting `OSStatus`.
+   */
+  static func osStatus(from error: Error) -> OSStatus {
+    if let error = error as? CocoaError,
+       let underlyingError = error.errorUserInfo["NSUnderlyingError"] as? NSError {
+      return OSStatus(clamping: underlyingError.code)
+    }
+
+    return 1
+  }
+}

--- a/Sources/utiluti/LockedValue.swift
+++ b/Sources/utiluti/LockedValue.swift
@@ -1,0 +1,24 @@
+//
+//  LockedValue.swift
+//  utiluti
+//
+
+import Foundation
+
+/**
+ Holds mutable process-local state behind `NSLock`.
+ */
+final class LockedValue<State>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var state: State
+
+  init(_ initialState: State) {
+    self.state = initialState
+  }
+
+  func withLock<Result>(_ body: (inout State) -> Result) -> Result {
+    lock.lock()
+    defer { lock.unlock() }
+    return body(&state)
+  }
+}

--- a/Sources/utiluti/ManageCommand.swift
+++ b/Sources/utiluti/ManageCommand.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import ArgumentParser
-import UniformTypeIdentifiers
 
 struct ManageCommand: AsyncParsableCommand {
   static let configuration = CommandConfiguration(
@@ -49,24 +48,18 @@ struct ManageCommand: AsyncParsableCommand {
   }
 
   func manageTypes(types: [String:Any]) async throws {
-    for (uti, value) in types {
-      var uti = uti
-      let display = uti
+    for (targetKey, value) in types {
+      let display = targetKey
+      let target = TypeTarget(managedKey: targetKey)
       
       guard let bundleID = value as? String
       else {
-        if verbose { print("skipping non-string value '\(value)' for \(uti)")}
+        if verbose { print("skipping non-string value '\(value)' for \(targetKey)")}
         continue
       }
-      
-      if uti.hasPrefix("extension:") {
-        let fileExt = String(uti.dropFirst(10))
-        if let utype = UTType(filenameExtension: fileExt) {
-          uti = utype.identifier
-        }
-      }
 
-      let result = await LSKit.setDefaultApp(identifier: bundleID, forTypeIdentifier: uti)
+      let result = await LSKit.setDefaultApp(identifier: bundleID, for: target)
+
       if result == 0 {
         print("set \(bundleID) for \(display)")
       } else {
@@ -115,4 +108,3 @@ struct ManageCommand: AsyncParsableCommand {
     }
   }
 }
-

--- a/Sources/utiluti/TypeCommands.swift
+++ b/Sources/utiluti/TypeCommands.swift
@@ -25,7 +25,7 @@ struct TypeCommands: AsyncParsableCommand {
     aliases: ["uti"]
   )
   
-  struct UTIdentifier: ParsableArguments {
+  struct TypeIdentifier: ParsableArguments {
     @Argument(help: ArgumentHelp(
       "universal type identifier, e.g. 'public.html'",
       discussion: "when --extension is present, this argument provides a file extension, e.g. 'txt'",
@@ -37,14 +37,9 @@ struct TypeCommands: AsyncParsableCommand {
       help: "provide a file extension instead of a UTI",
     )
     var fileExtension = false
-    
-    var identifier: String {
-      if fileExtension,
-         let identifier = UTType(filenameExtension: value){
-        return identifier.identifier
-      } else {
-        return value
-      }
+
+    var target: TypeTarget {
+      TypeTarget(value: value, isFileExtension: fileExtension)
     }
   }
   
@@ -63,20 +58,22 @@ struct TypeCommands: AsyncParsableCommand {
     static let configuration
     = CommandConfiguration(abstract: "Get the path to the default application.")
     
-    @OptionGroup var utidentifier: UTIdentifier
+    @OptionGroup var utidentifier: TypeIdentifier
     @OptionGroup var bundleID: IdentifierFlag
     
     func run() async {
-      guard let appURL = LSKit.defaultAppURL(forTypeIdentifier: utidentifier.identifier) else {
-        print("<no default app found>")
-        return
-      }
+      let target = utidentifier.target
+      let details = LSKit.defaultAppDetails(for: target)
+
       if bundleID.bundleID {
-        guard let appBundle = Bundle(url: appURL) else {
-          Self.exit(withError: ExitCode(6))
-        }
-        print(appBundle.bundleIdentifier ?? "<no identifier>")
+        print(details.bundleIdentifier ?? "<no default app found>")
       } else {
+        let appURL = details.appURL
+        guard let appURL else {
+          print("<no default app found>")
+          return
+        }
+
         print(appURL.path)
       }
     }
@@ -89,11 +86,11 @@ struct TypeCommands: AsyncParsableCommand {
       aliases: ["ls"]
     )
 
-    @OptionGroup var utidentifier: UTIdentifier
+    @OptionGroup var utidentifier: TypeIdentifier
     @OptionGroup var bundleID: IdentifierFlag
 
     func run() async {
-      let appURLs = LSKit.appURLs(forTypeIdentifier: utidentifier.identifier)
+      let appURLs = LSKit.appURLs(for: utidentifier.target)
       
       for appURL in appURLs {
         if bundleID.bundleID {
@@ -113,16 +110,16 @@ struct TypeCommands: AsyncParsableCommand {
     static let configuration
     = CommandConfiguration(abstract: "Set the default app for this type identifier.")
     
-    @OptionGroup var utidentifier: UTIdentifier
+    @OptionGroup var utidentifier: TypeIdentifier
     @Argument var identifier: String
     
     func run() async {
-      let result = await LSKit.setDefaultApp(identifier: identifier, forTypeIdentifier: utidentifier.identifier)
+      let result = await LSKit.setDefaultApp(identifier: identifier, for: utidentifier.target)
       
       if result == 0 {
-        print("set \(identifier) for \(utidentifier.identifier)")
+        print("set \(identifier) for \(utidentifier.target.displayValue)")
       } else {
-        print("cannot set default app for \(utidentifier.identifier) (error \(result))")
+        print("cannot set default app for \(utidentifier.target.displayValue) (error \(result))")
         TypeCommands.exit(withError: ExitCode(result))
       }
     }
@@ -132,10 +129,11 @@ struct TypeCommands: AsyncParsableCommand {
     static let configuration
     = CommandConfiguration(abstract: "prints the file extensions for the given type identifier")
     
-    @OptionGroup var utidentifier: UTIdentifier
+    @OptionGroup var utidentifier: TypeIdentifier
     
     func run() async {
-      guard let utype = UTType(utidentifier.identifier) else {
+      let utype = utidentifier.target.resolvedType
+      guard let utype else {
         print("<none>")
         TypeCommands.exit(withError: ExitCode(3))
       }
@@ -149,31 +147,74 @@ struct TypeCommands: AsyncParsableCommand {
     static let configuration
     = CommandConfiguration(abstract: "prints information for the given type identifier")
 
-    @OptionGroup var utidentifier: UTIdentifier
-    
-    func run() async {
-      guard let utype = UTType(utidentifier.identifier) else {
-        print("<none>")
-        TypeCommands.exit(withError: ExitCode(3))
+    @OptionGroup var utidentifier: TypeIdentifier
+
+    func printTypeInfo(for utype: UTType, includeIdentifier: Bool = true) {
+      if includeIdentifier {
+        print("uniform type identifier: \(utype.identifier)")
       }
-      print("uniform type identifier: \(utype.identifier)")
-      
+
       if let description = utype.localizedDescription {
         print("description: \(description)")
       }
-      
+
       for (key, value) in utype.tags {
         print("\(key): \(value)")
       }
-      
+
       if !utype.supertypes.isEmpty {
         print("super types: \(utype.supertypes.map(\.identifier))")
       }
-      
-      if let appURL = LSKit.defaultAppURL(forTypeIdentifier: utype.identifier),
-         let bundle = Bundle(url: appURL),
-         let identifier = bundle.bundleIdentifier {
-        print("default app: \(identifier) (\(appURL.path))")
+    }
+
+    func printDefaultApp(bundleIdentifier: String?, appURL: URL?) {
+      guard let bundleIdentifier else {
+        if let appURL {
+          print("default app: \(appURL.path)")
+        }
+        return
+      }
+
+      if let appURL {
+        print("default app: \(bundleIdentifier) (\(appURL.path))")
+      } else {
+        print("default app: \(bundleIdentifier)")
+      }
+    }
+
+    func run() async {
+      let target = utidentifier.target
+      let details = LSKit.defaultAppDetails(for: target)
+
+      switch target {
+      case .uti:
+        guard let utype = target.resolvedType else {
+          print("<none>")
+          TypeCommands.exit(withError: ExitCode(3))
+        }
+
+        printTypeInfo(for: utype)
+        printDefaultApp(
+          bundleIdentifier: details.bundleIdentifier,
+          appURL: details.appURL
+        )
+
+      case .fileExtension(let fileExtension):
+        print("requested extension: \(fileExtension)")
+
+        if let utype = target.resolvedType,
+           let resolvedIdentifier = target.resolvedIdentifier {
+          print("resolved UTI: \(resolvedIdentifier)")
+          print("dynamic UTI: \(target.hasDynamicResolvedIdentifier)")
+          printTypeInfo(for: utype, includeIdentifier: false)
+        } else {
+          print("resolved UTI: <none>")
+        }
+
+        printDefaultApp(
+          bundleIdentifier: details.bundleIdentifier,
+          appURL: details.appURL
+        )
       }
     }
   }

--- a/Sources/utiluti/TypeTarget.swift
+++ b/Sources/utiluti/TypeTarget.swift
@@ -1,0 +1,83 @@
+//
+//  TypeTarget.swift
+//  utiluti
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+enum TypeTarget: Equatable {
+  case uti(String)
+  case fileExtension(String)
+
+  init(value: String, isFileExtension: Bool) {
+    if isFileExtension {
+      self = .fileExtension(Self.normalizeExtension(value))
+    } else {
+      self = .uti(value)
+    }
+  }
+
+  init(managedKey: String) {
+    if managedKey.hasPrefix("extension:") {
+      let value = String(managedKey.dropFirst("extension:".count))
+      self = .fileExtension(Self.normalizeExtension(value))
+    } else {
+      self = .uti(managedKey)
+    }
+  }
+
+  static func normalizeExtension(_ value: String) -> String {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.hasPrefix(".") {
+      return String(trimmed.dropFirst()).lowercased()
+    } else {
+      return trimmed.lowercased()
+    }
+  }
+
+  var displayValue: String {
+    switch self {
+    case .uti(let identifier):
+      return identifier
+    case .fileExtension(let fileExtension):
+      return "extension:\(fileExtension)"
+    }
+  }
+
+  /**
+   Resolve the target to the best available UTI string. For extension input
+   this is only advisory; the caller can still fall back to the extension
+   path when Launch Services rejects the resolved type.
+   */
+  var resolvedIdentifier: String? {
+    resolvedType?.identifier
+  }
+
+  var hasDynamicResolvedIdentifier: Bool {
+    resolvedIdentifier?.hasPrefix("dyn.") ?? false
+  }
+
+  /**
+   The preferred UTI-based route for this target. Explicit UTIs always use
+   their original identifier, while extension input uses the resolved UTI
+   when one exists.
+   */
+  var preferredTypeIdentifier: String? {
+    switch self {
+    case .uti(let identifier):
+      return identifier
+    case .fileExtension:
+      return resolvedIdentifier
+    }
+  }
+
+  var resolvedType: UTType? {
+    switch self {
+    case .uti(let identifier):
+      return UTType(identifier)
+    case .fileExtension(let fileExtension):
+      return UTType(filenameExtension: fileExtension)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes how `utiluti` handles filename extensions.

Before this change, commands like `type -e ...` and `manage` entries like `extension:xcodeproj` would turn the extension into a UTI right away. That worked for common types, but it broke when macOS returned a dynamic `dyn.*` UTI. In those cases, `utiluti` could accept an extension as input but could not reliably set the handler for that extension.

With this change, `utiluti` keeps track of whether the target is a UTI or a file extension. If an extension maps cleanly to a UTI, it still uses that path. If not, it can fall back to the extension-specific Launch Services entry instead.

## What Changed

- `type` and `manage` now keep the original target kind instead of flattening everything into a UTI
- handler lookup and updates now go through one shared path for UTIs and extensions
- extension-specific Launch Services overrides are used when the UTI path is not enough

Please note that some parts of this code have been implemented using Codex, as I am not that strong in Swift